### PR TITLE
Typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If the operation failures N times (the failure threshold) the circuit
 moves to `closed`. Calls in the `closed` state will immediate fail and
 raise an exception. After a specified time period has passed (retry
 timeout) the circuit moves into `half-open`. Calls happen normally. If
-a call fails the state moves to `open`. If the call suceeds it moves
+a call fails the state moves to `closed`. If the call suceeds it moves
 to `open`. All calls are capped with a timeout. If a timeout occurs
 that counts as a failure.
 


### PR DESCRIPTION
I was reading the readme and it seems that all calls in the half closed state make the circuit move from half closed to open, even failed calls. I think this is a typo, but I haven't yet used the gem so I could be wrong!
